### PR TITLE
Feat bq reader patch 1

### DIFF
--- a/dvh_tools/bq_to_oracle/README.md
+++ b/dvh_tools/bq_to_oracle/README.md
@@ -3,8 +3,8 @@
 ```python
 from dvh_tools.bq_to_oracle import DataTransfer
 env = {
-    "gcp": "projects/21285645070/secrets/dvh_aareg_gcp_serviceaccount/versions/latest",
-    "oracle": "projects/21285645070/secrets/dvh_aareg_py/versions/latest",
+    "gcp": "projects/<project-id>/secrets/dvh_aareg_gcp_serviceaccount/versions/latest",
+    "oracle": "projects/<project-id>/secrets/dvh_aareg_py/versions/latest",
 }
 colums = ["column1", "column2"]
 table = {

--- a/dvh_tools/bq_to_oracle/data_transfer.py
+++ b/dvh_tools/bq_to_oracle/data_transfer.py
@@ -20,11 +20,9 @@ class DataTransfer:
         self.oracle_writer = OracleWriter(self.__config["oracle"], target_table=target_table)
         self.bq_reader = BQReader(self.__config["gcp"], source_query=source_query)
 
-    def run(self, batch_limit=None, dry_run=False, datatypes=None, convert_lists=False):
+    def run(self, batch_limit=None, datatypes=None, convert_lists=False):
         for i, batch in enumerate(self.bq_reader):
-            self.oracle_writer.write_batch(
-                batch, datatypes=datatypes, dry_run=dry_run, convert_lists=convert_lists
-            )
+            self.oracle_writer.write_batch(batch, datatypes=datatypes, convert_lists=convert_lists)
             if batch_limit:
                 if i > batch_limit:
                     self.oracle_writer.cleanup()

--- a/dvh_tools/bq_to_oracle/oracle_writer.py
+++ b/dvh_tools/bq_to_oracle/oracle_writer.py
@@ -11,16 +11,8 @@ class OracleWriter:
             dsn=self.__config["DB_DSN"],
         )
         self.target_table = target_table or self.__config["target-table"]
-        if self._table_is_not_empty():
-            raise ValueError(f"Target table {self.target_table} must be empty before ETL")
         self.insert_string = None
         self.total_rows_inserted = 0
-
-    def _table_is_not_empty(self) -> bool:
-        with self.con.cursor() as cursor:
-            cursor.execute(f"select 1 from {self.target_table} where rownum=1")
-            row = cursor.fetchone()
-        return row != None
 
     def write_batch(self, batch, dry_run=True, convert_lists=False, datatypes={}):
         if dry_run:


### PR DESCRIPTION
- tillat skriving til oracle selv om tabell er tom. Dette burde styres utenfor bq_to_oracle modul